### PR TITLE
Fixing minor typos with hyperlinks

### DIFF
--- a/docs/quick-authentication-ios-how-to.md
+++ b/docs/quick-authentication-ios-how-to.md
@@ -1,6 +1,6 @@
 # Sign-in users with a Microsoft Account to iOS apps using Microsoft Quick Authentication
 
-| [*Getting Started*](./quick-authentication-iOs-how-to.md)| [Reference](./quick-authentication-iOs-reference.md) |
+| [*Getting Started*](./quick-authentication-ios-how-to.md)| [Reference](./quick-authentication-ios-reference.md) |
 |--|--|
 
 On iOS, Microsoft Quick Authentication offers a library that makes it easy to add **Sign in with Microsoft** support to your mobile native app. Quick Authentication uses the Microsoft Authentication Library (MSAL) for iOS to handle authentication and authorization for users with personal Microsoft accounts.

--- a/docs/quick-authentication-ios-reference.md
+++ b/docs/quick-authentication-ios-reference.md
@@ -1,6 +1,6 @@
 # Microsoft Quick Authentication for iOS configuration and Objective-C API reference
 
-| [Getting Started](./quick-authentication-iOs-how-to.md)| [*Reference*](./quick-authentication-iOs-reference.md) |
+| [Getting Started](./quick-authentication-ios-how-to.md)| [*Reference*](./quick-authentication-ios-reference.md) |
 |--|--|
 
 These settings and APIs allow you to customize the appearance and behavior of the UI provided by Microsoft Quick Authentication and to invoke functionality provided by MSAL for iOS, such as signing out or requesting an access token for user information in the Microsoft Graph.


### PR DESCRIPTION
The problem with casing was causing 404 errors to show up on clicking links. Fixed them.