### PR TITLE
User/chbhatt/adding notes on blank html, unverified removal, Accountinfo and SignInAccountInfo

### DIFF
--- a/docs/quick-authentication-how-to.md
+++ b/docs/quick-authentication-how-to.md
@@ -551,9 +551,7 @@ Notice the `()` at the end, which causes the problem.
 
 ### Application showing up as "unverified".
 
-If your application shows up as "unverified" as in image below, please look at [this document](./partner-business-verification.md) on steps of how to resolve it.
-
-<br/> ![Application showing as unverified](./media/user-consent-dialog.PNG)
+If your application shows up as "unverified" as in the image below, please look at [this document](./partner-business-verification.md) on steps of how to resolve it.<br/> ![Application showing as unverified](./media/user-consent-dialog.PNG)
 
 ## Next steps
 

--- a/docs/quick-authentication-how-to.md
+++ b/docs/quick-authentication-how-to.md
@@ -341,13 +341,13 @@ To also enable logging for MSAL.js, add the [`logMsalEvents`](./quick-authentica
 ```
 ## Notes on Redirect URI for Single-Page application for popup mode
 
-If ux_mode is set to `'popup'` (which is default), then on clicking sign-in button or sign-in prompt, the credential / consent dialog opens up in a popup.
+If ux_mode is set to `'popup'` (which is the default), then on clicking the sign-in button or sign-in prompt, the credential / consent dialog opens up in a popup.
 
-The popup will be redirected to redirect URI [registered above](#register-your-application) and specified in quick authentication configuration using [login_uri](./quick-authentication-reference.md#data-type-initconfiguration) or [data-login_uri](./quick-authentication-reference.md#specifying-the-quick-authentication-initialization-parameters) by MSA server, once the credential entry / consenting process is completed on the server side. The redirection URL will contain a fragment with info needed by quick authentication to complete the sign-in process in client side.
+The popup will be redirected by MSA server to redirect URI [registered above](#register-your-application) and specified in quick authentication configuration using [login_uri](./quick-authentication-reference.md#data-type-initconfiguration) or [data-login_uri](./quick-authentication-reference.md#specifying-the-quick-authentication-initialization-parameters), once the credential entry / consenting process is completed on the server side. The redirection URL will contain a fragment with info needed by quick authentication to complete the sign-in process in client side.
 
-Quick authentication **needs** that the domain of the page which included our library is the same as domain of the redirect URI specified.
+Quick authentication **needs** the domain of the page which included our library to be the same as domain of the redirect URI specified.
 
-After server redirection, once quick authentication detects that the domain is same as the domain which loaded its Javascript library, it will close the popup and complete the sign-in process in client side.
+After server redirection, once quick authentication detects that the domain is same as the domain which loaded its Javascript library, it will close the popup and complete the sign-in process on the client side.
 
 This means that the user does not get an opportunity to see the redirect URI page. Hence we suggest using a blank.html page as redirect URI.
 

--- a/docs/quick-authentication-how-to.md
+++ b/docs/quick-authentication-how-to.md
@@ -54,7 +54,7 @@ Use the following settings for your app registration. **Bold text** in the table
 | **Name**                    | `SPA with Quick Auth`                                                  | Suggested value. You can change the app name at any time. |
 | **Supported account types** | **Personal Microsoft Accounts Only**                                   | Required value for Microsoft Quick Authentication.        |
 | **Platform type**           | **Single-Page Application**                                            | Required value for Microsoft Quick Authentication.        |
-| **Redirect URI for Single-Page application (SPA)**      | `http://localhost:<port>/blank.html` or `https://<your-tenant-id>/blank.html` | Recommended for Microsoft Quick Authentication.           |
+| **Redirect URI for Single-Page application (SPA)**      | `http://localhost:<port>/blank.html` or `https://<your-domain>/blank.html` | Recommended for Microsoft Quick Authentication. Check [this section](#notes-on-redirect-uri-for-single-page-application-for-popup-mode) for more details. |
 
 Redirect flow will need additional steps. Check [this section](#enabling-application-for-redirection) for more details.
 
@@ -339,6 +339,17 @@ To also enable logging for MSAL.js, add the [`logMsalEvents`](./quick-authentica
         src="https://edge-auth.microsoft.com/js/ms_auth_client.min.js?autoLogEvents=1&logMsalEvents=4"
         ></script>
 ```
+## Notes on Redirect URI for Single-Page application for popup mode
+
+If ux_mode is set to `'popup'` (which is default), then on clicking sign-in button or sign-in prompt, the credential / consent dialog opens up in a popup.
+
+The popup will be redirected to redirect URI [registered above](#register-your-application) and specified in quick authentication configuration using [login_uri](./quick-authentication-reference.md#data-type-initconfiguration) or [data-login_uri](./quick-authentication-reference.md#specifying-the-quick-authentication-initialization-parameters) by MSA server, once the credential entry / consenting process is completed on the server side. The redirection URL will contain a fragment with info needed by quick authentication to complete the sign-in process in client side.
+
+Quick authentication **needs** that the domain of the page which included our library is the same as domain of the redirect URI specified.
+
+After server redirection, once quick authentication detects that the domain is same as the domain which loaded its Javascript library, it will close the popup and complete the sign-in process in client side.
+
+This means that the user does not get an opportunity to see the redirect URI page. Hence we suggest using a blank.html page as redirect URI.
 
 ## Redirect mode
 
@@ -537,6 +548,12 @@ The following snippet is incorrect:
 ```
 
 Notice the `()` at the end, which causes the problem.
+
+### Application showing up as "unverified".
+
+If your application shows up as "unverified" as in image below, please look at [this document](./partner-business-verification.md) on steps of how to resolve it.
+
+<br/> ![Application showing as unverified](./media/user-consent-dialog.PNG)
 
 ## Next steps
 

--- a/docs/quick-authentication-reference.md
+++ b/docs/quick-authentication-reference.md
@@ -146,33 +146,33 @@ This is an optional string value which can be configured using any of the follow
 ## Data Type: AccountInfo
 
 This data type contains following values.
-| Property | Description |
-|----------|---------|
-| `fullName` | User's full name |
-| `surname` | User's surname |
-| `givenName` | User's given name |
-| `username` | User's email or phone number |
-| `email` | User's email address |
-| `photoUrl` | base64-encoded dataURI representing the user's avatar. If the user has set no avatar, its value will be `null`|
-| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). |
-| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL |
+| Property | Description | More info |
+|----------|---------|---------------|
+| `fullName` | User's full name | Can be empty |
+| `surname` | User's surname | Can be empty |
+| `givenName` | User's given name | Can be empty |
+| `username` | User's email or phone number | Not empty |
+| `email` | User's email address | Not empty |
+| `photoUrl` | base64-encoded dataURI representing the user's avatar. If the user has set no avatar, its value will be `null`| Can be empty |
+| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). | Not empty |
+| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL | Not empty |
 
 We recommend using either `id` or `homeAccountId` as a key, rather than the email address, because an email address isn't a unique account identifier. It's possible for a user to use a Gmail address for a Microsoft Account, and to potentially create two different accounts (a Microsoft account and a Google account) with that same email address. It's also possible for a Microsoft Account user to change the primary email address on their account.
 
 ## Data Type: SignInAccountInfo
 
 This data type contains all the fields of [AccountInfo](#data-type-accountinfo) and a new field `idToken`.
-| Property | Description |
-|----------|---------|
-| `fullName` | User's full name |
-| `surname` | the user's surname |
-| `givenName` | the user's given name |
-| `username` | User's email or phone number |
-| `email` | User's email address |
-| `photoUrl` | base64-encoded dataURI representing the user's avatar. If the user has set no avatar, its value will be `null`|
+| Property | Description | More info |
+|----------|---------|---------------|
+| `fullName` | User's full name | Can be empty |
+| `surname` | the user's surname | Can be empty |
+| `givenName` | the user's given name | Can be empty |
+| `username` | User's email or phone number | Not empty |
+| `email` | User's email address | Not empty |
+| `photoUrl` | base64-encoded dataURI representing the user's avatar. If the user has set no avatar, its value will be `null`| Can be empty |
 | `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). |
-| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL |
-| `idToken` | [ID token](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) received during sign-in process |
+| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL | Not empty |
+| `idToken` | [ID token](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) received during sign-in process | Not empty |
 
 We recommend using either `id` or `homeAccountId` as a key, rather than the email address, because an email address isn't a unique account identifier. It's possible for a user to use a Gmail address for a Microsoft Account, and to potentially create two different accounts (a Microsoft account and a Google account) with that same email address. It's also possible for a Microsoft Account user to change the primary email address on their account.
 

--- a/docs/quick-authentication-reference.md
+++ b/docs/quick-authentication-reference.md
@@ -170,7 +170,7 @@ This data type contains all the fields of [AccountInfo](#data-type-accountinfo) 
 | `username` | User's email or phone number | Not empty |
 | `email` | User's email address | Not empty |
 | `photoUrl` | base64-encoded dataURI representing the user's avatar. If the user has set no avatar, its value will be `null`| Can be empty |
-| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). |
+| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). | Not empty |
 | `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL | Not empty |
 | `idToken` | [ID token](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) received during sign-in process | Not empty |
 

--- a/docs/quick-authentication-reference.md
+++ b/docs/quick-authentication-reference.md
@@ -31,13 +31,13 @@ The `logMsalEvents` query parameter supports MSAL [log levels](https://azuread.g
 
 `autoLogEvents` needs to be set (can be any value) for `logMsalEvents` take effect.
 
-## Specifying the Quick Authenticaton initialization parameters
+## Specifying the Quick Authentication initialization parameters
 The following parameters can be used to initialize Quick Authentication. They are supplied as data attributes of the `ms-auth-initialize div` in your HTML. You can also choose to supply them programmatically in your Javascript (Refer to [Data Type: InitConfiguration](#data-type-initconfiguration)).
 
 | Property                     | Value(s)                                                                      | Default value                 | Required | More info                                                                                                   |
 |------------------------------|------------------------------------------------------------------------------|:-----------------------------:|----------|-------------------------------------------------------------------------------------------------------|
 | `data-client_id`             | **Application (client) ID**                                                   | (no default value)            | Yes      | See [Register your application](quick-authentication-how-to.md#register-your-application).   |
-| `data-login_uri`             | **Redirect URI for Single-page application**                                  | _https://&lt;domain&gt;/blank.html_ | Yes if `ux_mode == 'popup'`, else No | See [Register your application](quick-authentication-how-to.md#register-your-application). This URI is used when `ux_mode = 'popup'`.|
+| `data-login_uri`             | **Redirect URI for Single-page application**                                  | _https://&lt;domain&gt;/blank.html_ | Yes if `ux_mode == 'popup'`, else No | See [Register your application](quick-authentication-how-to.md#register-your-application). This URI is used when `ux_mode = 'popup'`. Check [this section](./quick-authentication-how-to.md#notes-on-redirect-uri-for-single-page-application-for-popup-mode) for some more details. |
 | `data-callback`              | JavaScript function that receives account information once sign-in completes. | (no default value)            | Yes      | On successful sign-in, this function is called with the [SignInAccountInfo](#data-type-signinaccountinfo) object. <br/> On sign-in failure, it is called with second argument [SignInErrorInfo](#data-type-signinerrorinfo) containing the error. |
 | `data-locale`                | `Language ID` strings in [table below](#supported-locales). e.g., `"en-US"`, `"fr-FR"`, etc. | `"en-US"`      | No       | Check `Language ID` column in [this table](#supported-locales) for possible values.                   |
 | `data-ux_mode`               | "popup"<br/> "redirect"                                                       | "popup"                       | No       | If "redirect" is set then button sign-in and [ms.auth.startSignIn](#method-msauthstartsignin) calls will use redirect flow |

--- a/docs/quick-authentication-reference.md
+++ b/docs/quick-authentication-reference.md
@@ -151,11 +151,11 @@ This data type contains following values.
 | `fullName` | User's full name | Can be empty |
 | `surname` | User's surname | Can be empty |
 | `givenName` | User's given name | Can be empty |
-| `username` | User's email or phone number | Not empty |
-| `email` | User's email address | Not empty |
+| `username` | User's email or phone number | Never empty |
+| `email` | User's email address | Never empty |
 | `photoUrl` | base64-encoded dataURI representing the user's avatar. If the user has set no avatar, its value will be `null`| Can be empty |
-| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). | Not empty |
-| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL | Not empty |
+| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). | Never empty |
+| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL | Never empty |
 
 We recommend using either `id` or `homeAccountId` as a key, rather than the email address, because an email address isn't a unique account identifier. It's possible for a user to use a Gmail address for a Microsoft Account, and to potentially create two different accounts (a Microsoft account and a Google account) with that same email address. It's also possible for a Microsoft Account user to change the primary email address on their account.
 
@@ -167,12 +167,12 @@ This data type contains all the fields of [AccountInfo](#data-type-accountinfo) 
 | `fullName` | User's full name | Can be empty |
 | `surname` | the user's surname | Can be empty |
 | `givenName` | the user's given name | Can be empty |
-| `username` | User's email or phone number | Not empty |
-| `email` | User's email address | Not empty |
+| `username` | User's email or phone number | Never empty |
+| `email` | User's email address | Never empty |
 | `photoUrl` | base64-encoded dataURI representing the user's avatar. If the user has set no avatar, its value will be `null`| Can be empty |
-| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). | Not empty |
-| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL | Not empty |
-| `idToken` | [ID token](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) received during sign-in process | Not empty |
+| `id` | an ID that is unique across all Microsoft accounts. This id can be used for some Microsoft Graph APIs (e.g., [User GET](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http)). | Never empty |
+| `homeAccountId` | User's [home account identifier](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) which is used by MSAL | Never empty |
+| `idToken` | [ID token](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) received during sign-in process | Never empty |
 
 We recommend using either `id` or `homeAccountId` as a key, rather than the email address, because an email address isn't a unique account identifier. It's possible for a user to use a Gmail address for a Microsoft Account, and to potentially create two different accounts (a Microsoft account and a Google account) with that same email address. It's also possible for a Microsoft Account user to change the primary email address on their account.
 


### PR DESCRIPTION
This PR does following:
1. Adds detailed notes on redirect_uri behavior in popup mode. This is explain when blank.html is apt for this scenario.
2. Adds an entry for "unverified" in troubleshooting section which points to the document with info on how to fix it.
3. Updates `AccountInfo` and `SignInAccountInfo` structure documentation to indicate which fields can be empty and which cannot be.