### PR TITLE
[iOS][Documentation] Update the Swift doc

### DIFF
--- a/docs/quick-authentication-ios-how-to.md
+++ b/docs/quick-authentication-ios-how-to.md
@@ -54,12 +54,23 @@ Now that you have created an application registration, you can extend it to iOS 
 ## Installing Microsoft Quick Authentication SDK
 To install the Microsoft Quick Authentication SDK in your development environment using CocoaPods, proceed as follows:
 1. Install CocoaPods following the instructions in the [Getting Started guide](https://guides.cocoapods.org/using/getting-started.html)
-2. Create a `Podfile` for your application and add `MicrosoftQuickAuth` under your target:
+2. Create a `Podfile` for your application and add `MicrosoftQuickAuth` or `MicrosoftQuickAuthSwiftSupport` under your target:
+
+Objective-C:
 ```
 use_frameworks!
  
 target 'your-target-here' do
   pod 'MicrosoftQuickAuth'
+end
+```
+
+Swift:
+```
+use_frameworks!
+
+target 'your-target-here' do
+  pod 'MicrosoftQuickAuthSwiftSupport'
 end
 ```
 3. Install the dependency:
@@ -70,18 +81,30 @@ end
 ## Initializing your application
 Create a `MSQAConfiguration` object to set the client ID for your application, which you will find in the Azure registration for your application. 
 
+Objective-C:
 ```objectivec
 #import <MSQA/MSQASignInClient.h>
 
 MSQAConfiguration *config = [[MSQAConfiguration alloc]
       initWithClientID:@"YOUR_IOS_CLIENT_ID"];
 ```
+Swift:
+```swift
+let config = MSQAConfiguration(clientID: "YOUR_IOS_CLIENT_ID")
+```
 and initialize a new instance of `MSQASignInClient` as follows:
+
+Objective-C:
 ```objectivec
 NSError *error = nil;
 MSQASignInClient *msSignInClient = [[MSQASignInClient alloc] initWithConfiguration:config
                                                                              error:&error];
 ```                                                           
+Swift:
+```swift
+if let client = try? MSQASignInClient(configuration: config) {
+})
+```
 If an error occured, `msSignInClient` returned will be nil and the `error` parameter will contain the error details.
 
 If the client ID is invalid, a later attempt to sign-in or acquire an access token will fail. The error will be reported to the user as follows:
@@ -119,6 +142,7 @@ Because Microsoft Quick Auth SDK builds on top of MSAL library, you will need to
 
 4.	To handle the sign-in callback, implement the following AppDelegate method to call `MSQASignInClient`’s `handleURL` to open a resource specified by the URL, and returns `YES` if the `MSQASignInClient` successfully handled the request
 
+Objective-C:
 ```objectivec
 - (BOOL)application:(UIApplication *)app
             openURL:(NSURL *)url
@@ -127,6 +151,13 @@ Because Microsoft Quick Auth SDK builds on top of MSAL library, you will need to
               handleURL:url
       sourceApplication:
           options[UIApplicationOpenURLOptionsSourceApplicationKey]];
+}
+```
+Swift:
+```swift
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    return client.handle(url, sourceApplication:
+       options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String)
 }
 ```
 
@@ -141,6 +172,8 @@ This will generate a sign-in button in your application as follows:
 ![Sign-in button](media/ios-sign-in-with.png)
 
 Alternatively, you can also add the button programmatically at runtime with the following code:
+
+Objective-C:
 ```objectivec
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -151,11 +184,26 @@ Alternatively, you can also add the button programmatically at runtime with the 
   [self.view addSubview:button];
 }
 ```
+Swift:
+```swift
+struct SignInView: View {
+  var body: some View {
+    Spacer()
+    MSQASignInButton(
+      viewModel: signInButtonViewModel,
+      action: { (accountInfo) -> Void in
+        // Handle account info here.
+      }
+    )
+  }
+}
+```
 It is possible to customize the appearance of the button. Refer to the [reference guide](quick-authentication-ios-reference.md#customizing-the-appearance-of-the-sign-in-button) for details.
 
 ## Getting a call back after the user has signed-in
 To get a callback after the user has completed the sign-in flow, or an error has occurred, set the completion block to be called using the `setSignInClient:viewController:completionBlock` method of `MSQASignInButton`, and return `YES` if setting the completion block is successful.
 
+Objective-C:
 ```objectivec
 BOOL success =
     [msSignInButton setSignInClient:_msSignInClient
@@ -205,6 +253,8 @@ On success, the completion block will be invoked with the `MSQAAccountInfo` cont
 
 ## Handling sign out
 To allow the user to sign out, in your application, connect a button to a method in the `ViewController` (called `signOut` in the example below) and call `MSQASignInClient`'s method `signOutWithCompletionBlock`:
+
+Objective-C:
 ```objectivec
 - (IBAction)signOut:(id)sender {
   [_msSignInClient
@@ -215,6 +265,14 @@ To allow the user to sign out, in your application, connect a button to a method
 }
 ```
 
+Swift:
+```swift
+client.signOut(completionBlock: {(error) in
+    if (error != nil) {
+        print(error.debugDescription)
+    }
+})
+```
 ## Troubleshoot specific errors
 
 ### Application showing up as "unverified".

--- a/docs/quick-authentication-ios-how-to.md
+++ b/docs/quick-authentication-ios-how-to.md
@@ -65,7 +65,7 @@ target 'your-target-here' do
 end
 ```
 
-Swift:
+SwiftUI:
 ```
 use_frameworks!
 

--- a/docs/quick-authentication-ios-how-to.md
+++ b/docs/quick-authentication-ios-how-to.md
@@ -102,8 +102,8 @@ MSQASignInClient *msSignInClient = [[MSQASignInClient alloc] initWithConfigurati
 ```                                                           
 Swift:
 ```swift
-if let client = try? MSQASignInClient(configuration: config) {
-})
+var error: NSError?
+let client = MSQASignInClient(configuration: config, error: &error)
 ```
 If an error occured, `msSignInClient` returned will be nil and the `error` parameter will contain the error details.
 
@@ -155,9 +155,15 @@ Objective-C:
 ```
 Swift:
 ```swift
-func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    return client.handle(url, sourceApplication:
-       options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String)
+func application(
+  _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+) -> Bool {
+  let sourceApplication = options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String
+  if sourceApplication != nil {
+    return client.handle(
+      url, sourceApplication: sourceApplication!)
+  }
+  return false
 }
 ```
 
@@ -184,21 +190,36 @@ Objective-C:
   [self.view addSubview:button];
 }
 ```
-Swift:
+
+It is possible to customize the appearance of the button. Refer to the [reference guide](quick-authentication-ios-reference.md#customizing-the-appearance-of-the-sign-in-button) for details.
+
+For SwiftUI, you should create a `MSQASignInButtonViewModel` object first, setting the completion block to be called after sign-in flow is done as below:
+
 ```swift
-struct SignInView: View {
-  var body: some View {
-    Spacer()
-    MSQASignInButton(
-      viewModel: signInButtonViewModel,
-      action: { (accountInfo) -> Void in
-        // Handle account info here.
-      }
-    )
-  }
+var signInButtonViewModel = MSQASignInButtonViewModel(
+  signInClient: MSQASignInClient(
+    configuration: MSQAConfiguration(clientID: "YOUR_IOS_CLIENT_ID"), error: nil
+  ), presentingViewController: self,
+  completionBlock: { (account, error) in
+    if (account != nil) {
+      // Use account.
+    }
+    if (error != nil) {
+      // Handle errors.
+    }
+  })
+```
+
+then add the button with the following code:
+
+```swift
+var body: some View {
+  Spacer()
+  MSQASignInButton(viewModel: signInButtonViewModel)
+    .accessibilityIdentifier("MSQASignInButton")
+    .padding()
 }
 ```
-It is possible to customize the appearance of the button. Refer to the [reference guide](quick-authentication-ios-reference.md#customizing-the-appearance-of-the-sign-in-button) for details.
 
 ## Getting a call back after the user has signed-in
 To get a callback after the user has completed the sign-in flow, or an error has occurred, set the completion block to be called using the `setSignInClient:viewController:completionBlock` method of `MSQASignInButton`, and return `YES` if setting the completion block is successful.
@@ -218,7 +239,6 @@ BOOL success =
                        }
                      }];
 ```
-
 On success, the completion block will be invoked with the `MSQAAccountInfo` containing the following information:
 
 ```objectivec
@@ -250,6 +270,8 @@ On success, the completion block will be invoked with the `MSQAAccountInfo` cont
 
 @end
 ```
+
+For swift, please refer to [Adding a sign-in button to your application](#adding-a-sign-in-button-to-your-application) to check how to create a `MSQASignInButtonViewModel` object to set the completion block.
 
 ## Handling sign out
 To allow the user to sign out, in your application, connect a button to a method in the `ViewController` (called `signOut` in the example below) and call `MSQASignInClient`'s method `signOutWithCompletionBlock`:

--- a/docs/quick-authentication-ios-how-to.md
+++ b/docs/quick-authentication-ios-how-to.md
@@ -290,10 +290,10 @@ Objective-C:
 
 Swift:
 ```swift
-client.signOut(completionBlock: {(error) in
-    if (error != nil) {
-        print(error.debugDescription)
-    }
+client.signOut(completionBlock: { (error) in
+  if let error = error as? NSError {
+    print(error.description)
+  }
 })
 ```
 ## Troubleshoot specific errors

--- a/docs/quick-authentication-ios-how-to.md
+++ b/docs/quick-authentication-ios-how-to.md
@@ -239,6 +239,7 @@ BOOL success =
                        }
                      }];
 ```
+
 On success, the completion block will be invoked with the `MSQAAccountInfo` containing the following information:
 
 ```objectivec

--- a/docs/quick-authentication-ios-reference.md
+++ b/docs/quick-authentication-ios-reference.md
@@ -254,10 +254,10 @@ For example, use an `IBAction` and the code (Objective-C):
 
 Code example (Swift):
 ```swift
-client.signOut(completionBlock: {(error) in
-    if (error != nil) {
-        print(error.debugDescription)
-    }
+client.signOut(completionBlock: { (error) in
+  if let error = error as? NSError {
+    print(error.description)
+  }
 })
 ```
 ### MSQATokenCompletionBlock and MSQATokenResult

--- a/docs/quick-authentication-ios-reference.md
+++ b/docs/quick-authentication-ios-reference.md
@@ -25,12 +25,20 @@ For SwiftUI, you can create as the following:
 
 Code example (Swift):
 ```swift
-MSQASignInButton(
-  viewModel: signInButtonViewModel,
-  action: { (accountInfo) -> Void in
-    // Handle accountInfo here.
-  }
-)
+var signInButtonViewModel = MSQASignInButtonViewModel(
+  signInClient: MSQASignInClient(
+    configuration: MSQAConfiguration(clientID: "YOUR_IOS_CLIENT_ID"), error: nil
+  ), presentingViewController: self,
+  completionBlock: { (account, error) in
+    if (account != nil) {
+      // Use account.
+    }
+    if (error != nil) {
+      // Handle errors.
+    }
+  })
+
+MSQASignInButton(viewModel: signInButtonViewModel)
 ```
 
  ## Customizing the appearance of the sign-in button

--- a/docs/quick-authentication-ios-reference.md
+++ b/docs/quick-authentication-ios-reference.md
@@ -125,6 +125,37 @@ where `MSQAConfiguration` is defined as:
 @end
 ```
 
+Code example (Objective-C):
+
+```objectivec
+#import <MSQA/MSQASignInClient.h>
+
+MSQAConfiguration *config = [[MSQAConfiguration alloc]
+      initWithClientID:@"YOUR_IOS_CLIENT_ID"];
+```
+
+Swift:
+
+```swift
+let config = MSQAConfiguration(clientID: "YOUR_IOS_CLIENT_ID")
+```
+and initialize a new instance of `MSQASignInClient` as follows:
+
+Objective-C:
+
+```objectivec
+NSError *error = nil;
+MSQASignInClient *msSignInClient = [[MSQASignInClient alloc] initWithConfiguration:config
+                                                                             error:&error];
+```
+
+Swift:
+
+```swift
+var error: NSError?
+let client = MSQASignInClient(configuration: config, error: &error)
+```
+
 ### MSQACompletionBlock and MSQAAccountInfo
 
 `MSQASignInClient` methods that return account information do so by invoking an `MSQACompletionBlock` 
@@ -335,7 +366,7 @@ MSQASilentTokenParameters *parameters =
     MSQAWebviewParameters *webParameters = [[MSQAWebviewParameters alloc]
         initWithAuthPresentationViewController:self];
     MSQAInteractiveTokenParameters *params =
-        [[MSALInteractiveTokenParameters alloc]
+        [[MSQAInteractiveTokenParameters alloc]
              initWithScopes:@[ @"User.Read" ]
           webviewParameters:webParameters];
 
@@ -358,8 +389,8 @@ Code example (Swift):
 let parameters = MSQASilentTokenParameters(scopes: ["User.Read"])
 client.acquireTokenSilent(with: parameters, completionBlock: {(result, error) in
     if (error != nil) {
-        let webParams = MSALWebviewParameters(authPresentationViewController: self)
-        let interactiveParams = MSALInteractiveTokenParameters(scopes: ["User.Read"],webviewParameters: webParams)
+        let webParams = MSQAWebviewParameters(authPresentationViewController: self)
+        let interactiveParams = MSQAInteractiveTokenParameters(scopes: ["User.Read"],webviewParameters: webParams)
         client.acquireToken(with: interactiveParams, completionBlock: {(result, error) in
             if (error == nil) {
                 // Use access token.

--- a/docs/quick-authentication-ios-reference.md
+++ b/docs/quick-authentication-ios-reference.md
@@ -10,9 +10,10 @@ For information about how to use Quick Authentication for iOS, see [Sign-in user
 > Microsoft Quick Authentication is in public preview. This preview is provided without a service-level agreement and isn't recommended for production workloads. Some features might be unsupported or have constrained capabilities. For more information, see [Supplemental terms of use for Microsoft Azure previews](https://azure.microsoft.com/en-us/support/legal/preview-supplemental-terms/).
 
 ## Creating a sign-in button
+
 Refer to the [how to guide](quick-authentication-ios-how-to.md#adding-a-sign-in-button-to-your-application) to learn how to create a sign-in button declaratively in a storyboard or XIB file.
 
-You can also create the sign-in button programmatically using: 
+For UIKit, you can also create the sign-in button programmatically using:
 ```objectivec
 - (instancetype)initWithFrame:(CGRect)frame
 ```
@@ -20,8 +21,20 @@ Code example (Objective-C):
 ```
 MSQASignInButton* msSignInButton = [[MSQASignInButton alloc] initWithFrame:CGRectMake(0, 0, 100, 20)];
 ```
+For SwiftUI, you can create as the following:
+
+Code example (Swift):
+```swift
+MSQASignInButton(
+  viewModel: signInButtonViewModel,
+  action: { (accountInfo) -> Void in
+    // Handle accountInfo here.
+  }
+)
+```
 
  ## Customizing the appearance of the sign-in button
+ ### UIKit
 To customize the appearance of the button, you can set the following properties on the `MSQASignInButton` instance:
 
 | Properties |  Description | Values | Default value |
@@ -37,10 +50,27 @@ Example code:
 ```objectivec
 msSignInButton.theme = kMSQASignInButtonThemeDark;
 msSignInButton.type = kMSQASignInButtonTypeStandard;
-```
 
+```
 You can connect the button to a `IBOutlet MSQASignInButton*` member in your ViewController.
 
+### SwiftUI
+
+For SwiftUI, to customize the appearance of the button, you can set the following properties on `MSQASignInButtonViewModel` object passed to the `MSQASignInButton`.
+| Properties |  Description | Values | Default value |
+| -- | -- | -- | -- |
+| type | The button type | standard<br> icon|standard |
+| theme | The button visual theme | dark<br>  light |	dark |
+| size | Predefined sizes. If width or height are specified, they override this setting.<br> **Large**:<br>&nbsp; width: 280px<br>&nbsp; height: 42px<br>&nbsp; textSize: 16px<br>&nbsp; iconSize: 20px<br> **Medium**:<br>&nbsp; width: 280px<br>&nbsp; height: 36px<br>&nbsp; textSize: 14px<br>&nbsp; iconSize: 16px<br> **Small**:<br>&nbsp; width: 280px<br>&nbsp; height: 28px<br>&nbsp; textSize: 12px<br>&nbsp; iconSize: 12px | small<br> medium<br> large | large |
+| text |	Button text	| signInWith<br> signUpWith <br> signIn<br> continueWith | signInWith |
+| shape | Shape of button corners. | rectangular<br> pill<br>rounded |rectangular |
+| logoAlignment | Where the Microsoft logo should be in the button | logoTextLeft<br> logoLeftTextCenter | logoTextLeft |
+
+Example code:
+```swift
+signInButtonViewModel.theme = .dark
+signInButtonViewModel.text = .signInWith;
+```
 ## MSQASignInClient Methods
 The following methods of `MSQASignInClient` offer programmatic triggering of the sign-in flow and additional functionality. Note that these methods are asynchronous and internally dispatch their work to another thread. As a result, they can be called on the main thread and their completion block will be called back asynchronously on the same thread. 
 
@@ -151,6 +181,17 @@ Code example (Objective-C):
   }
 }];
 ```
+Code example (Swift):
+```swift
+client.getCurrentAccount(completionBlock: {(account, error) in
+    if (account != nil) {
+      // Use account
+    }
+    if (error != nil) {
+     // Handle the error
+    }
+})
+```
 ### MSQASignInClient method: signInWithViewController:completionBlock
 Interactively signs-in the user into your site and returns the account asynchronously through the callback.
 ```objectivec
@@ -182,6 +223,18 @@ Code example (Objective-C):
       // Use these values in UX.
     }];
 ```
+Code example (Swift):
+```swift
+client.signIn(with: self, completionBlock:  {(account, error) in
+    if (account == nil) {
+        return
+    }
+    let fullName = account?.fullName
+    let userName = account?.userName
+    let photo = UIImage(data: Data(base64Encoded:(account?.base64Photo!)!)!)
+    // Use these values in UX.
+})
+```
 
 ### MSQASignInClient method: signOutWithCompletionBlock
 Add a sign-out button to your app and connect the button to a method in your ViewController that calls:
@@ -199,6 +252,14 @@ For example, use an `IBAction` and the code (Objective-C):
 }
 ```
 
+Code example (Swift):
+```swift
+client.signOut(completionBlock: {(error) in
+    if (error != nil) {
+        print(error.debugDescription)
+    }
+})
+```
 ### MSQATokenCompletionBlock and MSQATokenResult
 
 `MSQASignInClient` methods that return token information do so by invoking an `MSQATokenCompletionBlock` 
@@ -284,6 +345,25 @@ MSQASilentTokenParameters *parameters =
   }}];
 ```
 
+Code example (Swift):
+```swift
+let parameters = MSQASilentTokenParameters(scopes: ["User.Read"])
+client.acquireTokenSilent(with: parameters, completionBlock: {(result, error) in
+    if (error != nil) {
+        let webParams = MSALWebviewParameters(authPresentationViewController: self)
+        let interactiveParams = MSALInteractiveTokenParameters(scopes: ["User.Read"],webviewParameters: webParams)
+        client.acquireToken(with: interactiveParams, completionBlock: {(result, error) in
+            if (error == nil) {
+                // Use access token.
+            } else {
+                // Check the error
+            }
+        })
+    } else {
+        let token = result?.accessToken
+    }
+})
+```
 ### MSQASignInClient method: acquireTokenSilentWithParameters:completionBlock
 Attempt to acquires an access token to access additional account information about the user without interaction with the user. Fails if it is not possible.
 ```objectivec
@@ -311,6 +391,17 @@ MSQASilentTokenParameters *parameters =
                               // Check the error
                             }
                           }];
+```
+Code example (Swift):
+```swift
+let parameters = MSQASilentTokenParameters(scopes: ["User.Read"])
+client.acquireTokenSilent(with: parameters, completionBlock: {(result, error) in
+    if (error == nil) {
+      // Use access token.
+    } else {
+      // Check the error
+    }
+})
 ```
 
 ##	Logging


### PR DESCRIPTION
This patch adds the Swift instructions for the following docs:

- quick-authentication-ios-how-to.md
- quick-authentication-ios-reference.md