### PR TITLE
Typo in quick-authentication-ios-how-to.md

### DIFF
--- a/docs/quick-authentication-ios-how-to.md
+++ b/docs/quick-authentication-ios-how-to.md
@@ -156,7 +156,7 @@ Objective-C:
 Swift:
 ```swift
 func application(
-  _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  _ app: UIApplication, openURL: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]
 ) -> Bool {
   let sourceApplication = options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String
   if sourceApplication != nil {


### PR DESCRIPTION
In code sample:

func application(
  _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]
) -> Bool {
...
Shouldn't "open url" be "openURL"?

For issue : https://github.com/microsoft/quick-authentication/issues/56 